### PR TITLE
Only no-clip players if the block is solid

### DIFF
--- a/src/main/java/net/arcaniax/buildersutilities/BuildersUtilities.java
+++ b/src/main/java/net/arcaniax/buildersutilities/BuildersUtilities.java
@@ -71,10 +71,15 @@ public final class BuildersUtilities extends JavaPlugin {
         instance = this;
 
         this.settings = new Settings(new CustomConfig(this, "config.yml"));
-        this.noClipManager = new NoClipManager();
+
+        this.noClipManager = new NoClipManager(this);
+        this.noClipManager.start();
+
         this.nmsManager = new NmsManager();
+
         this.inventoryManager = new InventoryManager(this);
         this.inventoryManager.init();
+
         BannerUtil.addColors();
         BannerUtil.addPatterns();
 

--- a/src/main/java/net/arcaniax/buildersutilities/NoClipManager.java
+++ b/src/main/java/net/arcaniax/buildersutilities/NoClipManager.java
@@ -26,8 +26,9 @@ package net.arcaniax.buildersutilities;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -35,64 +36,61 @@ import java.util.UUID;
 
 public class NoClipManager {
 
-    public static Set<UUID> noClipPlayerIds;
+    public static Set<UUID> noClipPlayerIds = new HashSet<>();
+    private final JavaPlugin javaPlugin;
 
-    public NoClipManager() {
-        noClipPlayerIds = new HashSet<>();
-        Bukkit.getScheduler().runTaskTimer(BuildersUtilities.getInstance(), this::checkForBlocks, 1L, 1L);
+    public NoClipManager(
+            final @NonNull JavaPlugin javaPlugin
+    ) {
+        this.javaPlugin = javaPlugin;
+    }
+
+    public void start() {
+        Bukkit.getScheduler().runTaskTimer(javaPlugin, this::checkForBlocks, 1L, 1L);
     }
 
     private void checkForBlocks() {
-        for (UUID name : noClipPlayerIds) {
-            Player player = Bukkit.getPlayer(name);
-            if (player != null && player.isOnline()) {
-                if (player.getGameMode().equals(GameMode.CREATIVE)) {
-                    boolean noClip;
-                    if (player.getLocation().add(0, -0.1, 0).getBlock().getType() != Material.AIR && player
-                            .isSneaking()) {
-                        noClip = true;
-                    } else {
-                        noClip = isNoClip(player);
-                    }
-                    if (noClip) {
-                        player.setGameMode(GameMode.SPECTATOR);
-                    }
-                } else if (player.getGameMode().equals(GameMode.SPECTATOR)) {
-                    boolean noClip;
-                    if (player.getLocation().add(0, -0.1, 0).getBlock().getType() != Material.AIR) {
-                        noClip = true;
-                    } else {
-                        noClip = isNoClip(player);
-                    }
-                    if (!noClip) {
-                        player.setGameMode(GameMode.CREATIVE);
-                    }
+        for (final UUID id : noClipPlayerIds) {
+            final Player p = javaPlugin.getServer().getPlayer(id);
+
+            if (p == null || !p.isOnline()) {
+                continue;
+            }
+
+            final boolean noClip;
+            if (p.getGameMode() == GameMode.CREATIVE) {
+                if (p.getLocation().add(0, -0.1, 0).getBlock().getType().isSolid() && p.isSneaking()) {
+                    noClip = true;
+                } else {
+                    noClip = this.shouldNoClip(p);
+                }
+
+                if (noClip) {
+                    p.setGameMode(GameMode.SPECTATOR);
+                }
+            } else if (p.getGameMode() == GameMode.SPECTATOR) {
+                if (p.getLocation().add(0, -0.1, 0).getBlock().getType().isSolid()) {
+                    noClip = true;
+                } else {
+                    noClip = this.shouldNoClip(p);
+                }
+
+                if (!noClip) {
+                    p.setGameMode(GameMode.CREATIVE);
                 }
             }
         }
     }
 
-    private boolean isNoClip(Player player) {
-        boolean noClip = false;
-        if (player.getLocation().add(+0.4, 0, 0).getBlock().getType() != Material.AIR) {
-            noClip = true;
-        } else if (player.getLocation().add(-0.4, 0, 0).getBlock().getType() != Material.AIR) {
-            noClip = true;
-        } else if (player.getLocation().add(0, 0, +0.4).getBlock().getType() != Material.AIR) {
-            noClip = true;
-        } else if (player.getLocation().add(0, 0, -0.4).getBlock().getType() != Material.AIR) {
-            noClip = true;
-        } else if (player.getLocation().add(+0.4, 1, 0).getBlock().getType() != Material.AIR) {
-            noClip = true;
-        } else if (player.getLocation().add(-0.4, 1, 0).getBlock().getType() != Material.AIR) {
-            noClip = true;
-        } else if (player.getLocation().add(0, 1, +0.4).getBlock().getType() != Material.AIR) {
-            noClip = true;
-        } else if (player.getLocation().add(0, 1, -0.4).getBlock().getType() != Material.AIR) {
-            noClip = true;
-        } else if (player.getLocation().add(0, +1.9, 0).getBlock().getType() != Material.AIR) {
-            noClip = true;
-        }
-        return noClip;
+    private boolean shouldNoClip(final Player player) {
+        return player.getLocation().add(+0.4, 0, 0).getBlock().getType().isSolid()
+                || player.getLocation().add(-0.4, 0, 0).getBlock().getType().isSolid()
+                || player.getLocation().add(0, 0, +0.4).getBlock().getType().isSolid()
+                || player.getLocation().add(0, 0, -0.4).getBlock().getType().isSolid()
+                || player.getLocation().add(+0.4, 1, 0).getBlock().getType().isSolid()
+                || player.getLocation().add(-0.4, 1, 0).getBlock().getType().isSolid()
+                || player.getLocation().add(0, 1, +0.4).getBlock().getType().isSolid()
+                || player.getLocation().add(0, 1, -0.4).getBlock().getType().isSolid()
+                || player.getLocation().add(0, +1.9, 0).getBlock().getType().isSolid();
     }
 }


### PR DESCRIPTION
## Overview
This pull-request changes NoClipManager's behavior so that players are only no-clipped if the block is solid. This allows players to pass through objects that they normally would be able to such as tall grass, flowers, and mushrooms without being set to spectator mode.

Additionally, NoClipManager now gets the main plugin instance through constructor dependency injection rather than getting the instance through BuildersUtilities' static getter, and the repeating task is started through a separate method, #start, rather than in the constructor.

(Some small code style changes have also been made, hope you don't mind ;p)

**Fixes #49**

## Comparison of Behaviors
old: https://gfycat.com/goodnaturedunimportantalpineroadguidetigerbeetle
new: https://gfycat.com/achingseveregalapagosdove

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
