### PR TITLE
Fix typo in utilities menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This plugin is a collection of a lot of tiny features that help with building.
 * [Download](https://www.spigotmc.org/resources/builders-utilities.42361/)
 * [Development Builds](https://ci.athion.net/job/Builders-Utilities/)
 * [Discord](https://discord.gg/jpRVrjd)
-* [Issues](https://github.com/Brennian/Builders-Utilities/issues)
+* [Issues](https://github.com/Arcaniax-Development/Builders-Utilities/issues)
 
 # Building
 Gradle is the recommended way to build the project. Use `./gradlew build` in the main project directory to build the project.
@@ -28,4 +28,4 @@ Gradle is the recommended way to build the project. Use `./gradlew build` in the
 See [here](https://github.com/Brennian/Builders-Utilities/blob/master/CONTRIBUTING.md)
 
 ## Suggestions
-Suggestions are welcome! We have a separate issue form for suggestions, that can be found [here](https://github.com/Brennian/Builders-Utilities/issues).
+Suggestions are welcome! We have a separate issue form for suggestions, which can be found [here](https://github.com/Arcaniax-Development/Builders-Utilities/issues).

--- a/src/main/java/net/arcaniax/buildersutilities/menus/SecretBlockMenuProvider.java
+++ b/src/main/java/net/arcaniax/buildersutilities/menus/SecretBlockMenuProvider.java
@@ -33,8 +33,6 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Arrays;
-
 public class SecretBlockMenuProvider implements InventoryProvider {
 
     private static final ItemStack SPAWNER = Items.create(Material.SPAWNER, ChatColor.BLUE + "Spawner", "");

--- a/src/main/java/net/arcaniax/buildersutilities/menus/UtilitiesMenuProvider.java
+++ b/src/main/java/net/arcaniax/buildersutilities/menus/UtilitiesMenuProvider.java
@@ -51,7 +51,7 @@ public class UtilitiesMenuProvider implements InventoryProvider {
 
     private static final String IRON_TRAPDOOR_LORE = "__&c__&8&oActs like wooden trapdoors";
     private static final String SLAB_BREAKING_LORE = "__&c__&8&oHold any slab to break double slab blocks";
-    private static final String GLAZED_ROTATING_LORE = "__&c__&8&oShift right click with emtpy hand";
+    private static final String GLAZED_ROTATING_LORE = "__&c__&8&oShift right click with empty hand";
 
     private static final String NIGHT_VISION_LORE = "__&c__&8&oSee in the dark";
     private static final String NO_CLIP_LORE = "__&c__&8&oFly through blocks with ease";


### PR DESCRIPTION

## Overview
This pull request fixes a typo in the hover text of an item in the utilities menu.

Additionally, an unused import was removed and in the README, outdated links were updated and a grammatical error was fixed.

Fixes #56

## Checklist
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
