### PR TITLE
Set false default permissions to op default

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -71,8 +71,8 @@ permissions:
   builders.util.terracotta:
     default: true
   builders.util.nightvision:
-    default: false
+    default: op
   builders.util.noclip:
-    default: false
+    default: op
   builders.util.advancedfly:
-    default: false
+    default: op


### PR DESCRIPTION
## Overview
This pull request sets op as the default for permissions in the plugin.yml which currently have false as their default. This gives operators full access to plugin features.

Fixes #58

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
