### PR TITLE
Fix incorrect permission being checked

### DIFF
--- a/src/main/java/net/arcaniax/buildersutilities/menus/UtilitiesMenuProvider.java
+++ b/src/main/java/net/arcaniax/buildersutilities/menus/UtilitiesMenuProvider.java
@@ -68,7 +68,7 @@ public class UtilitiesMenuProvider implements InventoryProvider {
     }
 
     private void setIronTrapdoorItem(Player player, InventoryContents contents) {
-        if (!player.hasPermission("builders.util.irontrapdoor")) {
+        if (!player.hasPermission("builders.util.trapdoor")) {
             setNoPermission(1, contents);
             contents.set(1, 1, ClickableItem.empty(
                     Items.create(Material.IRON_TRAPDOOR, "&6Iron Trapdoor Interaction", "&7&lNo Permission")));


### PR DESCRIPTION
## Overview
The utilities menu currently checks the wrong permission for trapdoor functionality. This pull request fixes that by checking the correct permission.

**Fixes #60**

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
