### PR TITLE
Add doors to exclusion list for block physics disabling

### DIFF
--- a/src/main/java/net/arcaniax/buildersutilities/listeners/BlockPhysicsListener.java
+++ b/src/main/java/net/arcaniax/buildersutilities/listeners/BlockPhysicsListener.java
@@ -68,7 +68,8 @@ public class BlockPhysicsListener implements Listener {
                     e.getChangedType().name().toLowerCase().contains("fence") ||
                     e.getChangedType().name().toLowerCase().contains("pane") ||
                     e.getChangedType().name().toLowerCase().contains("wall") ||
-                    e.getChangedType().name().toLowerCase().contains("bar")) {
+                    e.getChangedType().name().toLowerCase().contains("bar") ||
+                    e.getChangedType().name().toLowerCase().contains("door")) {
                 return;
             }
         } catch (Exception ex) {


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/Arcaniax-Development/Builders-Utilities/issues
-->

https://www.spigotmc.org/threads/door-bug.385433/

Fixes #94 

## Description

This PR adds an exception to items containing the word "door" so that block physics still applies to doors. This prevents them from being half-opened and half-closed whenever a player interacts with them.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
