### PR TITLE
exclude flow and guster banner patterns on 1.20.5/6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.19.3-R0.1-SNAPSHOT")
     compileOnly("com.mojang:authlib:1.5.25")
     implementation("org.bstats:bstats-bukkit:3.0.2")
     implementation("org.bstats:bstats-base:3.0.2")

--- a/src/main/java/net/arcaniax/buildersutilities/utils/BannerUtil.java
+++ b/src/main/java/net/arcaniax/buildersutilities/utils/BannerUtil.java
@@ -19,6 +19,7 @@
 package net.arcaniax.buildersutilities.utils;
 
 import com.cryptomorin.xseries.XMaterial;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.DyeColor;
 import org.bukkit.block.banner.Pattern;
@@ -43,11 +44,30 @@ public class BannerUtil {
     private static final Random random = new Random();
 
     public static void addPatterns() {
+        String version = Bukkit.getMinecraftVersion();
+        boolean experimental = version.equals("1.20.5") || version.equals("1.20.6");
+
         for (PatternType pt : PatternType.values()) {
-            if (!pt.equals(PatternType.BASE)) {
+            if (patternAllowed(pt, experimental)) {
                 allPatterns.add(pt);
             }
         }
+    }
+
+    private static boolean patternAllowed(PatternType pt, boolean experimental) {
+        if (pt.equals(PatternType.BASE)) {
+            return false;
+        }
+
+        // flow and guster patterns are experimental in 1.20.5/6.
+        if (experimental) {
+            String id = pt.getIdentifier();
+            if (id.equalsIgnoreCase("flw") || id.equalsIgnoreCase("gus")) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public static void addColors() {

--- a/src/main/java/net/arcaniax/buildersutilities/utils/BannerUtil.java
+++ b/src/main/java/net/arcaniax/buildersutilities/utils/BannerUtil.java
@@ -44,8 +44,8 @@ public class BannerUtil {
     private static final Random random = new Random();
 
     public static void addPatterns() {
-        String version = Bukkit.getMinecraftVersion();
-        boolean experimental = version.equals("1.20.5") || version.equals("1.20.6");
+        String version = Bukkit.getVersion(); // #getMinecraftVersion does not exist on Spigot; lame!
+        boolean experimental = version.contains("1.20.5") || version.contains("1.20.6");
 
         for (PatternType pt : PatternType.values()) {
             if (patternAllowed(pt, experimental)) {


### PR DESCRIPTION
## Overview
**Fixes issue with banner menu reported by Bloody_Mind on Discord.** [Link to message.](https://discord.com/channels/298439357092724736/738389934229946501/1262786624992051273)

<img width="1192" alt="image" src="https://github.com/user-attachments/assets/967e23a7-085a-405f-8944-46e581173da0">

## Description
The flow and guster banner patterns are experimental on 1.20.5 and 1.20.6. Attempting to add these patterns to the banner menu if the experimental data pack is not enabled will result in an exception.

Ideally, we would use `Registry.BANNER_PATTERN` to retrieve available patterns; however, we're still targeting 1.19.3, in which that registry does not exist. As a workaround, this PR checks whether the server version is 1.20.5/6, and if so, prevents the flow and guster patterns from being added to the menu.

## Checklist
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
