### PR TITLE
Fix forbidden old paper maven url

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ repositories {
     mavenCentral()
     maven {
         name = "Paper"
-        url = uri("https://papermc.io/repo/repository/maven-public/")
+        url = uri("https://repo.papermc.io/repository/maven-public/")
     }
     maven {
         name = "Mojang"


### PR DESCRIPTION
## Description
Paper has made the existing paper maven url forbidden, because you should be using repo.papermc.io.
This is why the builds are failing.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
