### PR TITLE
Update redstone

### DIFF
--- a/src/main/java/net/arcaniax/buildersutilities/listeners/BlockPhysicsListener.java
+++ b/src/main/java/net/arcaniax/buildersutilities/listeners/BlockPhysicsListener.java
@@ -74,6 +74,17 @@ public class BlockPhysicsListener implements Listener {
             if (blockName.contains("redstone") ||
                     blockName.contains("daylight") ||
                     blockName.contains("diode") ||
+                    blockName.contains("repeater") ||
+                    blockName.contains("comparator") ||
+                    blockName.contains("door") ||
+                    blockName.contains("target") ||
+                    blockName.contains("structure") ||
+                    blockName.contains("jukebox") ||
+                    blockName.contains("crafter") ||
+                    blockName.contains("powered_rail") ||
+                    blockName.contains("detector_rail") ||
+                    blockName.contains("activator_rail") ||
+                    blockName.contains("hopper") ||
                     blockName.contains("note") ||
                     blockName.contains("lever") ||
                     blockName.contains("button") ||


### PR DESCRIPTION
## Overview
**Fixes https://github.com/Arcaniax-Development/Builders-Utilities/issues/118**

## Description
Redstone setting doesn't work for repeaters anymore because a redstone Repeater is not called a `DIODE` anymore, it's called a `REPEATER`

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code

Jar for people looking for a fix:
[Builders-Utilities-2.1.1-119-redstone.zip](https://github.com/user-attachments/files/23150599/Builders-Utilities-2.1.1-119-redstone.zip)
