### PR TITLE
Fixes the gradle wrapper validation to point to the new one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - name: "Checkout Repository"
         uses: actions/checkout@v5
       - name : "Validate Gradle Wrapper"
-        uses : "gradle/wrapper-validation-action@v3"
+        uses : "gradle/actions/wrapper-validation@v5"
       - name : "Grab SHA"
         uses : "benjlevesque/short-sha@v3.0"
         id : "short-sha"


### PR DESCRIPTION
## Overview
gradle/actions/wrapper-validation@v5 is the new standard gradle wrapper validator the wrapper-validation-action is not valid anymore, and causes the GitHub actions to fail currently. It's now under GitHub actions itself.

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
